### PR TITLE
Implemented config file

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace FanControl.Liquidctl
+{
+    public class Config
+    {
+        public class LiquidctlRecord
+        {
+            public class MatchRecord
+            {
+                public string device { get; set; }
+                public List<string> set { get; set; }
+            }
+
+            public string exePath { get; set; }
+            public List<MatchRecord> match { get; set; }
+        }
+
+        public LiquidctlRecord liquidctl { get; set; }
+    }
+}

--- a/FanControl.Liquidctl.csproj
+++ b/FanControl.Liquidctl.csproj
@@ -32,12 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FanControl.Plugins">
-      <HintPath>..\..\..\..\Documents\FanControl\FanControl.Plugins.dll</HintPath>
+      <HintPath>..\..\Tools\FanControl_net_7_0\FanControl.Plugins.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\Documents\FanControl\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -47,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config.cs" />
     <Compile Include="LiquidctlCLIWrapper.cs" />
     <Compile Include="LiquidctlDevice.cs" />
     <Compile Include="LiquidctlStatusJSON.cs" />
@@ -56,6 +58,9 @@
   <ItemGroup>
     <None Include="build-liquidctl.sh" />
     <None Include="build-release.ps1" />
+    <None Include="packages.config" />
+    <None Include="FanControl.Liquidctl.json" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/FanControl.Liquidctl.json
+++ b/FanControl.Liquidctl.json
@@ -1,0 +1,14 @@
+{
+	"liquidctl": {
+		"exePath": "liquidctl.exe",
+		"match": [
+			{
+				"device": "kraken",
+				"set": [
+					"ring color breathing 05445E 189AB4 75E6DA D4F1F4",
+					"logo color spectrum-wave --speed slower"
+				]
+			}
+		]
+	}
+}

--- a/LiquidctlCLIWrapper.cs
+++ b/LiquidctlCLIWrapper.cs
@@ -1,33 +1,46 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Diagnostics;
-using Newtonsoft.Json;
+using FanControl.Plugins;
+using Newtonsoft.Json.Linq;
 
 namespace FanControl.Liquidctl
 {
-    internal static class LiquidctlCLIWrapper
+    internal class LiquidctlCLIWrapper
     {
-        public static string liquidctlexe = "Plugins\\liquidctl.exe"; //TODO extract path to executable to config
-        internal static void Initialize()
+        internal static IPluginLogger logger;
+        internal static Config config;
+
+        internal static void Initialize(Config pluginConfig, IPluginLogger pluginLogger)
         {
+            config = pluginConfig;
+            logger = pluginLogger;
+
             LiquidctlCall($"--json initialize all");
+
+            foreach(var match in config.liquidctl.match)
+            {
+                foreach(var cmd in match.set)
+                {
+                    LiquidctlCall($"--match {match.device} set {cmd}");
+                }
+            }
         }
         internal static List<LiquidctlStatusJSON> ReadStatus()
         {
             Process process = LiquidctlCall($"--json status");
-            return JsonConvert.DeserializeObject<List<LiquidctlStatusJSON>>(process.StandardOutput.ReadToEnd());
+            return ParseStatuses(process.StandardOutput.ReadToEnd());
         }
         internal static List<LiquidctlStatusJSON> ReadStatus(string address)
         {
             Process process = LiquidctlCall($"--json --address {address} status");
-            return JsonConvert.DeserializeObject<List<LiquidctlStatusJSON>>(process.StandardOutput.ReadToEnd());
+            return ParseStatuses(process.StandardOutput.ReadToEnd());
         }
         internal static void SetPump(string address, int value)
         {
             LiquidctlCall($"--address {address} set pump speed {(value)}");
         }
-        
+
         internal static void SetFan(string address, int value)
         {
             LiquidctlCall($"--address {address} set fan speed {(value)}");
@@ -43,9 +56,12 @@ namespace FanControl.Liquidctl
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
 
-            process.StartInfo.FileName = liquidctlexe;
+            process.StartInfo.FileName = config.liquidctl.exePath;
             process.StartInfo.Arguments = arguments;
 
+#if DEBUG
+            logger.Log($"Calling: {config.liquidctl.exePath} {arguments}");
+#endif
             process.Start();
             process.WaitForExit();
 
@@ -55,6 +71,30 @@ namespace FanControl.Liquidctl
             }
 
             return process;
+        }
+
+        private static List<LiquidctlStatusJSON> ParseStatuses(string json)
+        {
+#if DEBUG
+            logger.Log($"Got: {json}");
+#endif
+            JArray statusArray = JArray.Parse(json);
+            List<LiquidctlStatusJSON> statuses = new List<LiquidctlStatusJSON>();
+
+            foreach (JObject statusObject in statusArray)
+            {
+                try
+                {
+                    LiquidctlStatusJSON status = statusObject.ToObject<LiquidctlStatusJSON>();
+                    statuses.Add(status);
+                }
+                catch(Exception e)
+                {
+                    logger.Log($"Unable to parse {statusObject}\ne.Message");
+                }
+            }
+
+            return statuses;
         }
     }
 }

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
1. Plugin failed to run with older version of liquidctl cause of the StatusRecord.value has type float, but ctl returned a string. Improved the status parsing to log failed devices. Now plugin will be loaded regardless of parsing issues.
2. Implemented config file called `FanControl.Liquidctl.json`.  It supports sending custom `match` commands to device (e.g. set color).
```json
{
  "liquidctl": {
    "exePath": "liquidctl.exe",
    "match": [
      {
        "device": "kraken",
        "set": [
          "ring color breathing 05445E 189AB4 75E6DA D4F1F4",
          "logo color spectrum-wave --speed slower"
        ]
      }
    ]
  }
}
```